### PR TITLE
docs: prefer cloning with SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Requirements:
 Clone the repo, amd build the mcp server:
 
 ```shell
-$ git clone https://github.com/algolia/mcp
+$ git clone git@github.com:algolia/mcp.git
 $ cd mcp/cmd/mcp
 $ go build
 ```


### PR DESCRIPTION
This updates the README to avoid cloning with HTTP and prefer SSH instead.