### PR TITLE
feat(run_query): allow passing an index

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -50,7 +50,7 @@ func main() {
 		server.WithLogging(),
 	)
 
-	amcp.RegisterRunQuery(mcps, index)
+	amcp.RegisterRunQuery(mcps, index, client)
 	amcp.RegisterGetObject(mcps, index)
 	amcp.RegisterGetSettings(mcps, index)
 	amcp.RegisterSearchRules(mcps, index)

--- a/runquery.go
+++ b/runquery.go
@@ -13,7 +13,7 @@ import (
 	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
 )
 
-func RegisterRunQuery(mcps *server.MCPServer, index *search.Index) {
+func RegisterRunQuery(mcps *server.MCPServer, index *search.Index, client *search.Client) {
 	runQueryTool := mcp.NewTool(
 		"run_query",
 		mcp.WithDescription("Run a query against the Algolia search index"),


### PR DESCRIPTION
This allows passing a different index when performing a query. When not passed, it fallbacks on the one set in the environment.

I'm not well-versed enough yet with how (or if) this could be done with MCP but from a UX perspective, a better experience could be not to default and prompt for an index name when not passed.

If this PR works for you, I can implement that in all tools.