### PR TITLE
chore: ignore executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cmd/mcp/mcp


### PR DESCRIPTION
This avoids accidentally tracking the executable.