### PR TITLE
feat: enable tools based on ACL of the api key used

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ In Claude desktop edit the settings as per https://modelcontextprotocol.io/quick
          "env": {
             "ALGOLIA_APP_ID": "<APP_ID>",
             "ALGOLIA_INDEX_NAME": "<INDEX_NAME>",
-            "ALGOLIA_API_KEY": "<API_KEY>",
-            "ALGOLIA_WRITE_API_KEY": "<ADMIN_API_KEY>"  /* if you want to allow write operations, use your ADMIN key here */
+            "ALGOLIA_API_KEY": "<API_KEY>"
          }
       }
    }
@@ -66,7 +65,6 @@ From the repo root, setup the environment
 $ export ALGOLIA_APP_ID=""
 $ export ALGOLIA_INDEX_NAME=""
 $ export ALGOLIA_API_KEY=""
-$ export ALGOLIA_WRITE_API_KEY=""  # if you want to allow write operations, use your ADMIN key here
 ```
 Move into the server directory, and rebuild (if necessary):
 ```shell

--- a/pkg/search/indices/getsettings.go
+++ b/pkg/search/indices/getsettings.go
@@ -2,6 +2,7 @@ package indices
 
 import (
 	"context"
+	"slices"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -10,7 +11,10 @@ import (
 	"github.com/algolia/mcp/pkg/mcputil"
 )
 
-func RegisterGetSettings(mcps *server.MCPServer, index *search.Index) {
+func RegisterGetSettings(mcps *server.MCPServer, ACL []string, index *search.Index) {
+	if slices.Index(ACL, "settings") == -1 {
+		return
+	}
 	getSettingsTool := mcp.NewTool(
 		"get_settings",
 		mcp.WithDescription("Get the settings for the Algolia index"),

--- a/pkg/search/query/runquery.go
+++ b/pkg/search/query/runquery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -14,7 +15,10 @@ import (
 	"github.com/algolia/mcp/pkg/mcputil"
 )
 
-func RegisterRunQuery(mcps *server.MCPServer, client *search.Client, index *search.Index) {
+func RegisterRunQuery(mcps *server.MCPServer, ACL []string, client *search.Client, index *search.Index) {
+	if slices.Index(ACL, "search") == -1 {
+		return
+	}
 	runQueryTool := mcp.NewTool(
 		"run_query",
 		mcp.WithDescription("Run a query against the Algolia search index"),

--- a/pkg/search/records/getobject.go
+++ b/pkg/search/records/getobject.go
@@ -3,6 +3,7 @@ package records
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -11,7 +12,10 @@ import (
 	"github.com/algolia/mcp/pkg/mcputil"
 )
 
-func RegisterGetObject(mcps *server.MCPServer, index *search.Index) {
+func RegisterGetObject(mcps *server.MCPServer, ACL []string, index *search.Index) {
+	if slices.Index(ACL, "search") == -1 {
+		return
+	}
 	getObjectTool := mcp.NewTool(
 		"get_object",
 		mcp.WithDescription("Get an object by its object ID"),

--- a/pkg/search/rules/searchrules.go
+++ b/pkg/search/rules/searchrules.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -12,7 +13,10 @@ import (
 	"github.com/algolia/mcp/pkg/mcputil"
 )
 
-func RegisterSearchRules(mcps *server.MCPServer, index *search.Index) {
+func RegisterSearchRules(mcps *server.MCPServer, ACL []string, index *search.Index) {
+	if slices.Index(ACL, "settings") == -1 {
+		return
+	}
 	searchRulesTool := mcp.NewTool(
 		"search_rules",
 		mcp.WithDescription("Search for rules in the Algolia index"),

--- a/pkg/search/synonyms/searchsynonym.go
+++ b/pkg/search/synonyms/searchsynonym.go
@@ -3,6 +3,7 @@ package synonyms
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -11,7 +12,10 @@ import (
 	"github.com/algolia/mcp/pkg/mcputil"
 )
 
-func RegisterSearchSynonym(mcps *server.MCPServer, index *search.Index) {
+func RegisterSearchSynonym(mcps *server.MCPServer, ACL []string, index *search.Index) {
+	if slices.Index(ACL, "settings") == -1 {
+		return
+	}
 	searchSynonymTool := mcp.NewTool(
 		"search_synonyms",
 		mcp.WithDescription("Search for synonyms in the Algolia index that match a query"),


### PR DESCRIPTION
## What?

Enable the tools of the MCP server based on the ACL of the api key provided

## Test

With the admin key, 7 tools are registered:
<img width="539" alt="Screenshot 2025-04-15 at 15 41 39" src="https://github.com/user-attachments/assets/b6a28984-49ba-418e-8230-2d2275087d22" />

With the search only api key, only 2 are available:
<img width="541" alt="Screenshot 2025-04-15 at 15 42 37" src="https://github.com/user-attachments/assets/6fc94fed-45f9-4f3e-835e-cb5ec213555f" />
