### PR TITLE
feat: add delete rule and delete synoynm tools

### DIFF
--- a/cmd/mcp/main.go
+++ b/cmd/mcp/main.go
@@ -69,9 +69,11 @@ func main() {
 	query.RegisterRunQuery(mcps, client, index)
 
 	// Tools for managing rules
+	rules.RegisterDeleteRule(mcps, writeIndex)
 	rules.RegisterSearchRules(mcps, index)
 
 	// Tools for managing synonyms
+	synonyms.RegisterDeleteSynonym(mcps, writeIndex)
 	synonyms.RegisterSearchSynonym(mcps, index)
 
 	if err := server.ServeStdio(mcps); err != nil {

--- a/pkg/search/rules/deleterule.go
+++ b/pkg/search/rules/deleterule.go
@@ -1,0 +1,37 @@
+package rules
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/mcp/pkg/mcputil"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func RegisterDeleteRule(mcps *server.MCPServer, index *search.Index) {
+	deleteRuleTool := mcp.NewTool(
+		"delete_rule",
+		mcp.WithDescription("Delete a rule by its object ID"),
+		mcp.WithString(
+			"objectID",
+			mcp.Description("The object ID to delete"),
+			mcp.Required(),
+		),
+	)
+
+	mcps.AddTool(deleteRuleTool, func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		objectID, ok := req.Params.Arguments["objectID"].(string)
+		if !ok {
+			return mcp.NewToolResultError("invalid object format, expected JSON string"), nil
+		}
+
+		resp, err := index.DeleteRule(objectID)
+		if err != nil {
+			return nil, fmt.Errorf("could not delete rule: %w", err)
+		}
+
+		return mcputil.JSONToolResult("rule", resp)
+	})
+}

--- a/pkg/search/synonyms/deletesynonym.go
+++ b/pkg/search/synonyms/deletesynonym.go
@@ -1,0 +1,38 @@
+package synonyms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/algolia/algoliasearch-client-go/v3/algolia/search"
+	"github.com/algolia/mcp/pkg/mcputil"
+)
+
+func RegisterDeleteSynonym(mcps *server.MCPServer, index *search.Index) {
+	DeleteSynonymTool := mcp.NewTool(
+		"delete_synonym",
+		mcp.WithDescription("Delete a synonym by its object ID"),
+		mcp.WithString(
+			"objectID",
+			mcp.Description("The object ID to delete"),
+			mcp.Required(),
+		),
+	)
+
+	mcps.AddTool(DeleteSynonymTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		objectID, ok := req.Params.Arguments["objectID"].(string)
+		if !ok {
+			return mcp.NewToolResultError("invalid object format, expected JSON string"), nil
+		}
+
+		resp, err := index.DeleteRule(objectID)
+		if err != nil {
+			return nil, fmt.Errorf("could not delete synonyms: %w", err)
+		}
+
+		return mcputil.JSONToolResult("synonym", resp)
+	})
+}


### PR DESCRIPTION
## What?

Add tools for delete a rule or a synoynm:

## Test

Tested locally:
<img width="576" alt="Screenshot 2025-04-15 at 22 32 14" src="https://github.com/user-attachments/assets/ee84389f-b542-4773-b98c-3e9af60537d0" />
