### PR TITLE
Fix #35 -- Add main package entry point to support `go run`

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/algolia/mcp/cmd/mcp"
+
+var version = "dev"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
I think this should solve the issue I described in #35. Thanks for your consideration!