### PR TITLE
chore(analytics): implement simple get user count

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -8,4 +8,5 @@ func RegisterTools(mcps *server.MCPServer) {
 	RegisterGetNoResultsRate(mcps)
 	RegisterGetSearchesCount(mcps)
 	RegisterGetTopSearches(mcps)
+	RegisterGetUsersCount(mcps)
 }

--- a/pkg/analytics/get_users_count.go
+++ b/pkg/analytics/get_users_count.go
@@ -1,0 +1,107 @@
+package analytics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/algolia/mcp/pkg/mcputil"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// RegisterGetUsersCount registers the get_users_count tool with the MCP server.
+func RegisterGetUsersCount(mcps *server.MCPServer) {
+	getUsersCountTool := mcp.NewTool(
+		"analytics_get_users_count",
+		mcp.WithDescription("Retrieve the number of unique users within a time range, including a daily breakdown. By default, Algolia distinguishes search users by their IP address, unless you include a pseudonymous user identifier in your search requests with the userToken API parameter or x-algolia-usertoken request header."),
+		mcp.WithString(
+			"index",
+			mcp.Description("Index name"),
+			mcp.Required(),
+		),
+		mcp.WithString(
+			"startDate",
+			mcp.Description("Start date of the period to analyze, in YYYY-MM-DD format"),
+		),
+		mcp.WithString(
+			"endDate",
+			mcp.Description("End date of the period to analyze, in YYYY-MM-DD format"),
+		),
+		mcp.WithString(
+			"tags",
+			mcp.Description("Tags by which to segment the analytics"),
+		),
+	)
+
+	mcps.AddTool(getUsersCountTool, func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		appID := os.Getenv("ALGOLIA_APP_ID")
+		apiKey := os.Getenv("ALGOLIA_API_KEY")
+		if appID == "" || apiKey == "" {
+			return nil, fmt.Errorf("ALGOLIA_APP_ID and ALGOLIA_API_KEY environment variables are required")
+		}
+
+		// Extract parameters
+		index, _ := req.Params.Arguments["index"].(string)
+		if index == "" {
+			return nil, fmt.Errorf("index parameter is required")
+		}
+
+		// Create HTTP client and request
+		client := &http.Client{}
+		url := "https://analytics.algolia.com/2/users/count"
+		httpReq, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+
+		// Set headers
+		httpReq.Header.Set("x-algolia-application-id", appID)
+		httpReq.Header.Set("x-algolia-api-key", apiKey)
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		// Add query parameters
+		q := httpReq.URL.Query()
+		q.Add("index", index)
+
+		if startDate, ok := req.Params.Arguments["startDate"].(string); ok && startDate != "" {
+			q.Add("startDate", startDate)
+		}
+
+		if endDate, ok := req.Params.Arguments["endDate"].(string); ok && endDate != "" {
+			q.Add("endDate", endDate)
+		}
+
+		if tags, ok := req.Params.Arguments["tags"].(string); ok && tags != "" {
+			q.Add("tags", tags)
+		}
+
+		httpReq.URL.RawQuery = q.Encode()
+
+		// Execute request
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("failed to execute request: %w", err)
+		}
+		defer resp.Body.Close()
+
+		// Check for error response
+		if resp.StatusCode != http.StatusOK {
+			var errResp map[string]any
+			if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+				return nil, fmt.Errorf("Algolia API error (status %d)", resp.StatusCode)
+			}
+			return nil, fmt.Errorf("Algolia API error: %v", errResp)
+		}
+
+		// Parse response
+		var result map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return nil, fmt.Errorf("failed to parse response: %w", err)
+		}
+
+		return mcputil.JSONToolResult("Users Count", result)
+	})
+}


### PR DESCRIPTION
Summary
This PR implements the getUsersCount operation from the Algolia Analytics API, adding the ability to retrieve the number of unique users within a specified time range, including a daily breakdown.

Changes
New file: [get_users_count.go](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Implements the analytics_get_users_count MCP tool
Calls the Analytics API endpoint GET /2/users/count
Supports optional date range filtering and tag segmentation
Updated: [analytics.go](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Registered the new [RegisterGetUsersCount](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) function in the [RegisterTools](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) method

API Details
Endpoint: https://analytics.algolia.com/2/users/count

Parameters:
[index](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (required): Index name to analyze
[startDate](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (optional): Start date in YYYY-MM-DD format
[endDate](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (optional): End date in YYYY-MM-DD format
[tags](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (optional): Tags for analytics segmentation
Response: Returns the total count of unique users and a daily breakdown showing user counts per day.

Implementation Notes
Follows the established pattern used by other analytics tools (e.g., [get_searches_count.go](vscode-file://vscode-app/private/var/folders/m4/vjm5vlfd5wq1k67_gzjzw_qm0000gp/T/AppTranslocation/1E5F891D-3530-4936-93F2-848395C98996/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
Uses the same authentication mechanism (environment variables ALGOLIA_APP_ID and ALGOLIA_API_KEY)
Includes proper error handling for API failures and invalid parameters
Returns results in the standard MCP tool result format

Testing
✅ Project builds successfully
✅ Tool is tested using the MCP inspector